### PR TITLE
Support for callbackURL to be a path instead of a full URL

### DIFF
--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -4,8 +4,18 @@
 var passport = require('passport')
   , util = require('util')
   , OAuth2 = require('oauth').OAuth2
-  , InternalOAuthError = require('../errors/internaloautherror');
-  
+  , InternalOAuthError = require('../errors/internaloautherror')
+  , tls = require('tls');
+
+
+extractHostname = function (req) {
+  var headers = req.headers
+    , protocol = (req.connection.server instanceof tls.Server || req.headers['x-forwarded-proto'] == 'https')
+               ? 'https://'
+               : 'http://'
+    , host = headers.host;
+  return protocol + host;
+};
 
 /**
  * `OAuth2Strategy` constructor.
@@ -94,6 +104,10 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
     //       query parameters, and should be propagated to the application.
     return this.fail();
+  }
+
+  if (this._callbackURL && this._callbackURL.indexOf('/') == 0) {
+    this._callbackURL = extractHostname(req) + this._callbackURL;
   }
   
   if (req.query && req.query.code) {

--- a/test/strategies/oauth2-test.js
+++ b/test/strategies/oauth2-test.js
@@ -724,6 +724,57 @@ vows.describe('OAuth2Strategy').addBatch({
     },
   },
   
+  'strategy handling a request to be redirected to a path for authorization': {
+    topic: function() {
+      var strategy = new OAuth2Strategy({
+          authorizationURL: 'https://www.example.com/oauth2/authorize',
+          tokenURL: 'https://www.example.com/oauth2/token',
+          clientID: 'ABC123',
+          clientSecret: 'secret',
+          callbackURL: '/auth/example/callback'
+        },
+        function(accessToken, refreshToken, profile, done) {}
+      );
+      
+      return strategy;
+    },
+    
+    'after augmenting with actions': {
+      topic: function(strategy) {
+        var self = this;
+        var req = {
+          connection: {},
+          headers: {
+            'host': 'www.example.net',
+            'x-forwarded-proto': 'https'
+          }
+        };
+        strategy.success = function(user) {
+          req.user = user;
+          self.callback(new Error('should-not-be-called'));
+        }
+        strategy.fail = function() {
+          self.callback(new Error('should-not-be-called'));
+        }
+        strategy.redirect = function(url) {
+          req.redirectURL = url;
+          self.callback(null, req);
+        }
+        
+        process.nextTick(function () {
+          strategy.authenticate(req);
+        });
+      },
+      
+      'should not call success or fail' : function(err, req) {
+        assert.isNull(err);
+      },
+      'should redirect to user authorization URL' : function(err, req) {
+        assert.equal(req.redirectURL, 'https://www.example.com/oauth2/authorize?response_type=code&redirect_uri=https%3A%2F%2Fwww.example.net%2Fauth%2Fexample%2Fcallback&client_id=ABC123&type=web_server');
+      },
+    },
+  },
+  
   'strategy handling a request to be redirected for authorization with a scope': {
     topic: function() {
       var strategy = new OAuth2Strategy({


### PR DESCRIPTION
This avoids having to hardcode the domain name in the passport setup, but use the protocol/hostname from each auth request instead.
