### PR TITLE
Pass the request to the verify callback

### DIFF
--- a/lib/passport-oauth/strategies/oauth.js
+++ b/lib/passport-oauth/strategies/oauth.js
@@ -78,6 +78,7 @@ function OAuthStrategy(options, verify) {
   this._userAuthorizationURL = options.userAuthorizationURL;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
   this._key = options.sessionKey || 'oauth';
+  this._passReqToCallback = options.passReqToCallback || false;
 }
 
 /**
@@ -139,11 +140,16 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       self._loadUserProfile(token, tokenSecret, params, function(err, profile) {
         if (err) { return self.error(err); };
         
-        self._verify(token, tokenSecret, profile, function(err, user, info) {
+        var done = function(err, user, info) {
           if (err) { return self.error(err); }
           if (!user) { return self.fail(info); }
           self.success(user, info);
-        });
+        };
+        if (self._passReqToCallback) {
+          self._verify(req, token, tokenSecret, profile, done);
+        } else {
+          self._verify(token, tokenSecret, profile, done);
+        }
       });
     });
   } else {

--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -74,6 +74,7 @@ function OAuth2Strategy(options, verify) {
   this._callbackURL = options.callbackURL;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
+  this._passReqToCallback = options.passReqToCallback || false;
 }
 
 /**
@@ -124,11 +125,16 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
         self._loadUserProfile(accessToken, function(err, profile) {
           if (err) { return self.error(err); };
           
-          self._verify(accessToken, refreshToken, profile, function(err, user, info) {
+          var done = function(err, user, info) {
             if (err) { return self.error(err); }
             if (!user) { return self.fail(info); }
             self.success(user, info);
-          });
+          };
+          if (self._passReqToCallback) {
+            self._verify(req, accessToken, refreshToken, profile, done);
+          } else {
+            self._verify(accessToken, refreshToken, profile, done);
+          }
         });
       }
     );


### PR DESCRIPTION
Pass the request on as the 5th parameter, unfortunately after the "done"
callback declaration in order to maintain backwards compatibility.

Adds support for more complex verifiers, that require
access to a session, currently logged in user, etc.

In my case I need access to req.user to see which user I should associate the token(s) with, since I need to support each user hooking up to several remote accounts.
