### PR TITLE
Add ability to access underlying response from auth. server 

### DIFF
--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -34,6 +34,10 @@ var passport = require('passport')
  *   - `clientSecret`      secret used to establish ownership of the client identifer
  *   - `callbackURL`       URL to which the service provider will redirect the user after obtaining authorization
  *   - `passReqToCallback` when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *   - `passAuthResultsToCallback` when `true`, an additional object is passed as the first argument to the verify 
+ *      callback.  The first element of this object contains `req` and the second contains the direct response 
+ *      from the authorization server. If this option is set to true, passReqToCallback should remain set to  false
+ *      (default: `false`)
  *
  * Examples:
  *
@@ -75,6 +79,7 @@ function OAuth2Strategy(options, verify) {
   this._callbackURL = options.callbackURL;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
+  this._passAuthResultsToCallback = options.passAuthResultsToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
 }
 
@@ -120,7 +125,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     //       time of this writing).  This parameter is not necessary, but its
     //       presence does not appear to cause any issues.
     this._oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL },
-      function(err, accessToken, refreshToken) {
+      function(err, accessToken, refreshToken, authResults) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
         
         self._loadUserProfile(accessToken, function(err, profile) {
@@ -134,7 +139,9 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
           
           if (self._passReqToCallback) {
             self._verify(req, accessToken, refreshToken, profile, verified);
-          } else {
+          } else if(self._passAuthResultsToCallback) {
+            self._verify({req: req, authResults: authResults}, accessToken, refreshToken, profile, verified);
+         } else {
             self._verify(accessToken, refreshToken, profile, verified);
           }
         });


### PR DESCRIPTION
It does not seem that the response from the oAuth authorization server is
made accessible.

There are some oAuth implementations that return additional information
from the authorization server when the initial request is made.
This information is only available in the initial response and
cannot be easily be recovered later (if at all) using additional calls against
the api with the access token.  SalesForce may be an example of this approach.
Force.com returns an id parameter in addition to the access token in the
response that allows access to useful information about the logged
in user (using the Salesforce Identity Service).

If the id parameter is not captured at that point you may not be able
to easily access additional information about the
logged in user such as their email address, etc.  In the case of
SalesForce it appears that this parameter can be rebuilt from
another query against the SalesForce servers but it would be
much easier if I could access it the first time it was sent from
the server.

I would like to add this functionality to the Force.com strategy
created by @joshbirk but I need that additional item to complete
this enhancement.

As a result, I have modified this project to optionally
include the results from the authorization server
as part of the verify callback.  Another possible approach
might be to expose the response in the Load User Profile function.
