### PR TITLE
Pass the raw result getOAuthAccessToken back to the Strategy's callback,...

### DIFF
--- a/lib/passport-oauth/strategies/oauth.js
+++ b/lib/passport-oauth/strategies/oauth.js
@@ -148,9 +148,9 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
         }
         
         if (self._passReqToCallback) {
-          self._verify(req, token, tokenSecret, profile, verified);
+          self._verify(req, token, tokenSecret, profile, verified, params);
         } else {
-          self._verify(token, tokenSecret, profile, verified);
+          self._verify(token, tokenSecret, profile, verified, params);
         }
       });
     });

--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -120,7 +120,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     //       time of this writing).  This parameter is not necessary, but its
     //       presence does not appear to cause any issues.
     this._oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL },
-      function(err, accessToken, refreshToken) {
+      function(err, accessToken, refreshToken, result) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
         
         self._loadUserProfile(accessToken, function(err, profile) {
@@ -133,9 +133,9 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
           }
           
           if (self._passReqToCallback) {
-            self._verify(req, accessToken, refreshToken, profile, verified);
+            self._verify(req, accessToken, refreshToken, profile, verified, result);
           } else {
-            self._verify(accessToken, refreshToken, profile, verified);
+            self._verify(accessToken, refreshToken, profile, verified, result);
           }
         });
       }

--- a/test/strategies/oauth-test.js
+++ b/test/strategies/oauth-test.js
@@ -33,14 +33,14 @@ vows.describe('OAuthStrategy').addBatch({
           consumerKey: 'ABC123',
           consumerSecret: 'secret'
         },
-        function(token, tokenSecret, profile, done) {
-          done(null, { token: token, tokenSecret: tokenSecret });
+        function(token, tokenSecret, profile, done, result) {
+          done(null, { token: token, tokenSecret: tokenSecret, expiresIn: result.expires_in });
         }
       );
       
       // mock
       strategy._oauth.getOAuthAccessToken = function(token, tokenSecret, verifier, callback) {
-        callback(null, 'access-token', 'access-token-secret', {});
+        callback(null, 'access-token', 'access-token-secret', { expires_in: 7200 });
       }
       
       return strategy;
@@ -75,6 +75,7 @@ vows.describe('OAuthStrategy').addBatch({
       'should authenticate' : function(err, req) {
         assert.equal(req.user.token, 'access-token');
         assert.equal(req.user.tokenSecret, 'access-token-secret');
+        assert.equal(req.user.expiresIn, 7200);
       },
       'should remove token and token secret from session' : function(err, req) {
         assert.isUndefined(req.session['oauth']);

--- a/test/strategies/oauth2-test.js
+++ b/test/strategies/oauth2-test.js
@@ -32,17 +32,17 @@ vows.describe('OAuth2Strategy').addBatch({
           clientSecret: 'secret',
           callbackURL: 'https://www.example.net/auth/example/callback',
         },
-        function(accessToken, refreshToken, profile, done) {
-          done(null, { accessToken: accessToken, refreshToken: refreshToken });
+        function(accessToken, refreshToken, profile, done, result) {
+          done(null, { accessToken: accessToken, refreshToken: refreshToken, expiresIn: result.expires_in });
         }
       );
       
       // mock
       strategy._oauth2.getOAuthAccessToken = function(code, options, callback) {
         if (options.redirect_uri == 'https://www.example.net/auth/example/callback')  {
-          callback(null, 'token', 'refresh-token');
+          callback(null, 'token', 'refresh-token', { acccess_token: 'token', refresh_token: 'refresh-token', expires_in: 3600 });
         } else {
-          callback(null, 'bad', 'really-bad');
+          callback(null, 'bad', 'really-bad', {});
         }
       }
       
@@ -74,6 +74,7 @@ vows.describe('OAuth2Strategy').addBatch({
       'should authenticate' : function(err, req) {
         assert.equal(req.user.accessToken, 'token');
         assert.equal(req.user.refreshToken, 'refresh-token');
+        assert.equal(req.user.expiresIn, 3600);
       },
     },
   },


### PR DESCRIPTION
... for use processing items such as expires_in.

Information from the access response is, at present, not accessible, yet is needed for writing routines such as handling of expires_in (part of the refresh token logics).
