### PR TITLE
Added token refreshing flow to passport.authenticate().

### DIFF
--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -111,9 +111,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     }
   }
   
-  if (req.query && req.query.code) {
-    var code = req.query.code;
-    
+  var grantType = options.grantType === 'refresh_token' ? options.grantType : 'authorization_code';
+  var code = grantType === 'refresh_token' ? options.refreshToken : (req.query ? req.query.code : null);
+
+  if (grantType === 'refresh_token' && !code) {
+    throw new Error('When grantType is "refresh_token" authenticate() requires a refreshToken option.');
+  }
+  
+  if (code) {
     // NOTE: The module oauth (0.9.5), which is a dependency, automatically adds
     //       a 'type=web_server' parameter to the percent-encoded data sent in
     //       the body of the access token request.  This appears to be an


### PR DESCRIPTION
From a refresh token clients may get a new unexpired access token.
For that, the code sent must be the refresh token (previously received) and the grant_type should be "refresh_token".

My modifications make that possible in a simple way without modifying the passport-oauth API.
Also, I maintained the author's style.

This will be useful for many.
