### PR TITLE
Adding options.customHeaders as the last parameter to OAuth2 creation.

### DIFF
--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -70,7 +70,7 @@ function OAuth2Strategy(options, verify) {
   //       allowed to use it when making protected resource requests to retrieve
   //       the user profile.
   this._oauth2 = new OAuth2(options.clientID,  options.clientSecret,
-                            '', options.authorizationURL, options.tokenURL);
+      '', options.authorizationURL, options.tokenURL, options.customHeaders);
 
   this._callbackURL = options.callbackURL;
   this._scope = options.scope;


### PR DESCRIPTION
Change is made in order to utilize customHeaders in OAuth2. See https://github.com/ciaranj/node-oauth/pull/116 for more detail.
