### PR TITLE
Enable customized headers for OAuth.

### DIFF
--- a/lib/passport-oauth/strategies/oauth.js
+++ b/lib/passport-oauth/strategies/oauth.js
@@ -69,13 +69,24 @@ function OAuthStrategy(options, verify) {
   if (!options.consumerKey) throw new Error('OAuthStrategy requires a consumerKey option');
   if (options.consumerSecret === undefined) throw new Error('OAuthStrategy requires a consumerSecret option');
   if (!verify) throw new Error('OAuth authentication strategy requires a verify function');
+  // Provide way of adding headers for OAuth while keeping its defaults
+  var headers = {"Accept" : "*/*",
+                 "Connection" : "close",
+                 "User-Agent" : "Node authentication"};
+  if (options.headers) {
+    var prop,
+        optheaders = options.headers;
+    for (prop in optheaders)
+      if (optheaders.hasOwnProperty(prop)) headers[prop] = optheaders[prop];
+  }
   
   // NOTE: The _oauth property is considered "protected".  Subclasses are
   //       allowed to use it when making protected resource requests to retrieve
   //       the user profile.
   this._oauth = new OAuth(options.requestTokenURL, options.accessTokenURL,
                           options.consumerKey,  options.consumerSecret,
-                          "1.0", null, options.signatureMethod || "HMAC-SHA1");
+                          "1.0", null, options.signatureMethod || "HMAC-SHA1",
+                          null, headers);
   
   this._userAuthorizationURL = options.userAuthorizationURL;
   this._callbackURL = options.callbackURL;


### PR DESCRIPTION
This is useful to specify the language when using LinkedIn API, for example.
