### PR TITLE
Optionally avoid parsing callbackURL

### DIFF
--- a/lib/passport-oauth/strategies/oauth2.js
+++ b/lib/passport-oauth/strategies/oauth2.js
@@ -100,9 +100,14 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
+
+  // Not all callbackURLs should be parsed.  For example, certain Google+ OAuth flows
+  // make use of a callbackURL of "postmessage."  This should not be considered a relative URL,
+  // but simple a string token.  To avoid parsing a callbackURL, specify parseCallbackURL: false
+  // in the options config object that's used to authenticate
   var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
+  var parseCallbackURL = (options.parseCallbackURL === undefined) || options.parseCallbackURL;
+  if (callbackURL && parseCallbackURL) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the


### PR DESCRIPTION
Certain Google+ OAuth flows make use of a callbackURL of `postmessage`, which is really just a string token.  It should not be treated as a URL.  This change introduces a new config property that can be included in the call to `authenticate`: `parseCallbackURL`.  If this is present and has a value of `false`, then the value of `callbackURL` will be included AS IS into the OAuth request.

Usage looks something like this:

``` javascript
    passport.authenticate('google', 
        { callbackURL: 'postmessage',
          parseCallbackURL: false }),
```

Please review/incorporate as desired.

Thanks,
--Doug
